### PR TITLE
dynamolock: use consistent reads

### DIFF
--- a/dynamolock/client.go
+++ b/dynamolock/client.go
@@ -591,8 +591,9 @@ func (c *Client) readFromDynamoDB(key string, sortKey *string) (*dynamodb.GetIte
 		dynamoDBKey[aws.StringValue(sortKey)] = &dynamodb.AttributeValue{S: sortKey}
 	}
 	return c.dynamoDB.GetItem(&dynamodb.GetItemInput{
-		TableName: aws.String(c.tableName),
-		Key:       dynamoDBKey,
+		ConsistentRead: aws.Bool(true),
+		TableName:      aws.String(c.tableName),
+		Key:            dynamoDBKey,
 	})
 }
 


### PR DESCRIPTION
I've probably missed out on something, but it seems that dynamolock isn't using consistent reads. This changes introduces consistent reads.

For reference, the original Java dynamodb-lock-client has used consistent reads since its very first commit.